### PR TITLE
fe3diag: reset KERNAL vectors at start-of-day

### DIFF
--- a/fe3diag.asm
+++ b/fe3diag.asm
@@ -47,6 +47,7 @@ LOADEND = $ae
 
 SOFT_RESET = 64802                      ;SOFT RESET
 CURSOR_POS = $e50a
+SY_INITVEC = $fd52
 
 BSOUT      = $ffd2
 GETIN      = $ffe4
@@ -131,6 +132,7 @@ COUNT   = FLGCOM
 
 
 TEST_PROGGI
+  jsr SY_INITVEC
   lda #<MSG_TITLE
   ldy #>MSG_TITLE
   jsr STROUT


### PR DESCRIPTION
If the wedge is active when the test hits BLK5 the CPU wanders off into
the weeds.

Signed-off-by: Simon J. Rowe <srowe@mose.org.uk>